### PR TITLE
attempt to complete location information for expressions

### DIFF
--- a/example/Main.elm
+++ b/example/Main.elm
@@ -53,7 +53,7 @@ expression e =
         List es _ ->
             withChild e (List.map expression es)
 
-        Application e1 e2 ->
+        Application e1 e2 m ->
             withChild e
                 [ expression e1
                 , expression e2

--- a/src/Ast/Helpers.elm
+++ b/src/Ast/Helpers.elm
@@ -28,6 +28,7 @@ type alias Meta =
     , column : Int
     }
 
+type alias Operator = (String, Meta)
 
 makeMeta : ParseLocation -> Meta
 makeMeta { line, column } =
@@ -139,8 +140,7 @@ emptyTuple : Parser s String
 emptyTuple =
     string "()"
 
-
-operator : Parser s String
+operator : Parser s Operator
 operator =
     lazy <|
         \() ->
@@ -149,7 +149,7 @@ operator =
                         if List.member n reservedOperators then
                             fail <| "operator '" ++ n ++ "' is reserved"
                         else
-                            succeed n
+                            withLocation (\l -> succeed (n,makeMeta l))
                     )
 
 

--- a/src/Ast/Statement.elm
+++ b/src/Ast/Statement.elm
@@ -83,7 +83,7 @@ allExport =
 
 functionExport : Parser s ExportSet
 functionExport =
-    FunctionExport <$> choice [ functionName, parens operator ]
+    FunctionExport <$> choice [ functionName, map (Tuple.first) (parens operator) ]
 
 
 constructorSubsetExports : Parser s ExportSet
@@ -319,7 +319,7 @@ functionTypeDeclaration : Parser s Statement
 functionTypeDeclaration =
     withMeta <|
         FunctionTypeDeclaration
-            <$> (choice [ loName, parens operator ] <* symbol ":")
+            <$> (choice [ loName, map (Tuple.first) (parens operator) ] <* symbol ":")
             <*> typeAnnotation
 
 
@@ -327,7 +327,7 @@ functionDeclaration : OpTable -> Parser s Statement
 functionDeclaration ops =
     withMeta <|
         FunctionDeclaration
-            <$> (choice [ loName, parens operator ])
+            <$> (choice [ loName, map (Tuple.first) (parens operator) ])
             <*> (many (between_ whitespace <| term ops))
             <*> (symbol "=" *> whitespace *> expression ops)
 
@@ -347,7 +347,7 @@ infixDeclaration =
                     , N <$ initialSymbol "infix"
                     ]
             <*> (spaces *> Combine.Num.int)
-            <*> (spaces *> (loName <|> operator))
+            <*> (spaces *> (loName <|> map (Tuple.first) operator))
 
 
 


### PR DESCRIPTION
So this is an attempt to complete location information for the Variable, Application and BinOp expression types.  A couple things to note.  I introduced a type for an operator internal to the parser.  Previously it had just been passed around as a string, but I wanted it to include location information.  Second, I'm still not sure that BinOp is ideal.  Currently the location (meta) for the BinOp expression is just the location of the operator.  Finally the change to hasLevel and related functions was not strictly necessary, but it is not exported, and this change makes the code a bit cleaner.

 